### PR TITLE
Fix remote link issue with docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,9 @@ makedocs(;
         ),
     ],
     modules=[MacaulayMatrix],
+    # Disable remote links because Documenter seems to have weird issues with it
+    # See https://github.com/JuliaAlgebra/MacaulayMatrix.jl/actions/runs/10199310419/job/28216095801
+    remotes = nothing,
 )
 
 deploydocs(

--- a/src/cvp.jl
+++ b/src/cvp.jl
@@ -3,13 +3,13 @@ import Manifolds
 import Manopt
 export eliminate_indices
 
-#"""
-#    function Ellipsoid{T,M<:AbstractMatrix}
-#        M::M
-#    end
-#
-#Represent the set `x'A'Ax = 1`.
-#"""
+"""
+    function Ellipsoid{T,M<:AbstractMatrix}
+        M::M
+    end
+
+Represent the set `x'A'Ax = 1`.
+"""
 struct Ellipsoid{T,M<:AbstractMatrix{T}} <: ManifoldsBase.AbstractManifold{ManifoldsBase.ℝ}
     A::M
 end


### PR DESCRIPTION
```julia
ERROR: LoadError: MissingRemoteError: unable to generate source url
  path: /home/runner/.julia/packages/MacaulayMatrix/SGhSC/src/matrix.jl:100:106
  module: MacaulayMatrix
Documenter was unable to automatically determine the remote repository for this file.
This can happen if you are including docstrings or pages from secondary packages. Those packages
must be cloned as Git repositories (i.e. Pkg.develop instead Pkg.add), or the `remotes` keyword
must be configured appropriately. See the 'Remote repository links' section in the manual for
more information.
Stacktrace:
  [1] source_url(doc::Documenter.Document, mod::Module, file::String, linerange::UnitRange{Int64})
    @ Documenter ~/.julia/packages/Documenter/qoyeC/src/documents.jl:895
```